### PR TITLE
Change from hard coded to env for php

### DIFF
--- a/vcfconvert.sh
+++ b/vcfconvert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/php -qC 
+#!/usr/bin/env php -qC 
 <?php
 
 /*


### PR DESCRIPTION
change line 1 from:
`#!/usr/bin/php -qC `
to:
`#!/usr/bin/env php -qC `

Took me forever to realize why it wasn't obeying changes to `php.ini`, was having a memory issue.